### PR TITLE
refactor(RobotBodyFilter): Removed frames/sensor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,21 @@ The basic workings of this filter are done via the [`filters::FilterBase` API](h
     once. If this is true, the processing pipeline expects the pointcloud
     to have fields int32 index, float32 stamps, and float32 vp_x, vp_y
     and vp_z viewpoint positions. If one of these fields is missing,
-    computeMask() throws runtime exception.
+    computeMask() throws runtime exception. For the LaserScan version, this
+    parameter should be set to the sensor frame if all messages are coming
+    from the same sensor. This will save some some conversions (cpu cycles).
 - `frames/fixed` (`string`, default: `"base_link"`)
 
     The fixed frame. Usually base_link for stationary robots (or sensor
     frame if both robot and sensor are stationary). For mobile robots, it
     can be e.g. odom or map. Only needed for point-by-point scans.
+- `frames/sensor` (`string`, default `""`)
 
-- `frames/filtering` (`string`, default: default is `frames/fixed`)
+    Frame of the sensor. In LaserScan version, it has to match the
+    `frame_id` of the incoming scans. In PointCloud2 version, the data
+    can come in a different frame from `frames/sensor`. The frame_id from
+    the incoming message will be taken as sensor frame if this value is `""`.
+- `frames/filtering` (`string`, default: `frames/fixed`)
 
     Frame in which the filter is applied. For point-by-point scans, it
     has to be a fixed frame, otherwise, it can be the sensor frame or

--- a/README.md
+++ b/README.md
@@ -82,12 +82,8 @@ The basic workings of this filter are done via the [`filters::FilterBase` API](h
     The fixed frame. Usually base_link for stationary robots (or sensor
     frame if both robot and sensor are stationary). For mobile robots, it
     can be e.g. odom or map. Only needed for point-by-point scans.
-- `frames/sensor` (`string`, default `"laser"`)
 
-    Frame of the sensor. In LaserScan version, it has to match the
-    `frame_id` of the incoming scans. In PointCloud2 version, the data 
-    can come in a different frame from `frames/sensor`.
-- `frames/filtering` (`string`, default: for point-by-point scans, default is `frames/fixed`, otherwise `frames/sensor`)
+- `frames/filtering` (`string`, default: default is `frames/fixed`)
 
     Frame in which the filter is applied. For point-by-point scans, it
     has to be a fixed frame, otherwise, it can be the sensor frame or

--- a/include/robot_body_filter/RobotBodyFilter.h
+++ b/include/robot_body_filter/RobotBodyFilter.h
@@ -294,7 +294,8 @@ protected:
    *             the INDEX channel.
    * \return Whether the computation succeeded.
    */
-  bool computeMask(const sensor_msgs::PointCloud2& projectedPointCloud, const std::string& sensorFrame,
+  bool computeMask(const sensor_msgs::PointCloud2& projectedPointCloud,
+                   const std::string& sensorFrame,
                    std::vector<RayCastingShapeMask::MaskValue>& mask);
 
   /** \brief Return the latest cached transform for the link corresponding to the given shape handle.

--- a/include/robot_body_filter/RobotBodyFilter.h
+++ b/include/robot_body_filter/RobotBodyFilter.h
@@ -119,13 +119,6 @@ protected:
    * odom or map. */
   std::string fixedFrame;
 
-  /** \brief Frame of the sensor. For LaserScan version, it is automatically
-   * read from the incoming data. For PointCloud2, you have to specify it
-   * explicitly because the pointcloud could have already been transformed e.g.
-   * to the fixed frame.
-   */
-  std::string sensorFrame;
-
   /** \brief Frame in which the filter is applied. For point-by-point scans, it
    * has to be a fixed frame, otherwise, it can be the sensor frame. */
   std::string filteringFrame;

--- a/include/robot_body_filter/RobotBodyFilter.h
+++ b/include/robot_body_filter/RobotBodyFilter.h
@@ -119,6 +119,13 @@ protected:
    * odom or map. */
   std::string fixedFrame;
 
+  /** \brief Frame of the sensor. For LaserScan version, it is automatically
+   * read from the incoming data. For PointCloud2, you have to specify it
+   * explicitly because the pointcloud could have already been transformed e.g.
+   * to the fixed frame.
+   */
+  std::string sensorFrame;
+
   /** \brief Frame in which the filter is applied. For point-by-point scans, it
    * has to be a fixed frame, otherwise, it can be the sensor frame. */
   std::string filteringFrame;
@@ -282,11 +289,13 @@ protected:
    *                            point captured at different time, it also needs
    *                            a float32 "stamps" channel and viewpoint
    *                            channels vp_x, vp_y and vp_z.
+   * \param sensorFrame Sensor frame id
    * \param mask Output mask of the points. Indices to the mask are taken from
    *             the INDEX channel.
    * \return Whether the computation succeeded.
    */
-  bool computeMask(const sensor_msgs::PointCloud2& projectedPointCloud, std::vector<RayCastingShapeMask::MaskValue>& mask);
+  bool computeMask(const sensor_msgs::PointCloud2& projectedPointCloud, const std::string& sensorFrame,
+                   std::vector<RayCastingShapeMask::MaskValue>& mask);
 
   /** \brief Return the latest cached transform for the link corresponding to the given shape handle.
    *


### PR DESCRIPTION
The sensor frame will now be derived from the incoming sensor messages.
This way, messages from different sensors can be processed and the
filter can be configured without any knowledge of the sensor.

Addresses #1 